### PR TITLE
don't require eula if no servers are enabled

### DIFF
--- a/nixos/modules/services/games/minecraft-servers/default.nix
+++ b/nixos/modules/services/games/minecraft-servers/default.nix
@@ -109,7 +109,7 @@ in {
   in {
     assertions = [
       {
-        assertion = cfg.eula;
+        assertion = (builtins.length enabledInstances) > 0 -> cfg.eula;
         message = "You must accept the Mojang EULA in order to run any servers.";
       }
 

--- a/nixos/modules/services/games/minecraft-servers/default.nix
+++ b/nixos/modules/services/games/minecraft-servers/default.nix
@@ -109,7 +109,7 @@ in {
   in {
     assertions = [
       {
-        assertion = (builtins.length enabledInstances) > 0 -> cfg.eula;
+        assertion = (builtins.length (builtins.attrNames enabledInstances)) > 0 -> cfg.eula;
         message = "You must accept the Mojang EULA in order to run any servers.";
       }
 


### PR DESCRIPTION
This is important if one wants to include the module on machines where they don't intend to host any servers.

My particular use-case is a wrapper module that I can have default-included on all my machines and only enable where needed. Since the NixOS module system can't handle imports conditional on configuration, I either have to accept the EULA on all my machines, or default-accept it in the wrapper, neither of which are nice solutions.